### PR TITLE
Check guild access

### DIFF
--- a/src/bob.js
+++ b/src/bob.js
@@ -171,7 +171,7 @@ for (let file of fs.readdirSync("./src/guild_configs")) {
 		throw new Error(`'src/guild_configs/${file}' doesn't have the property 'id'`);
 	}
 
-
+	// check if bot has access to guild in the guild config, if not continue
 	let guild;
 	try
 	{

--- a/src/bob.js
+++ b/src/bob.js
@@ -171,7 +171,15 @@ for (let file of fs.readdirSync("./src/guild_configs")) {
 		throw new Error(`'src/guild_configs/${file}' doesn't have the property 'id'`);
 	}
 
-	const guild = await client.guilds.fetch(guildInput.id);
+
+	let guild;
+	try
+	{
+		guild = await client.guilds.fetch(guildInput.id);
+	} catch (error) {
+		log(`bot does not have access to ${guildInput.abbreviation}`)
+		continue;
+	}
 
 	try {
 		await guild.init(guildInput);


### PR DESCRIPTION
Checks if the current instance of the bot has access to each guild in the guild_configs folder. If not, it logs to console and continues to next guild config.